### PR TITLE
Use `react-router-dom`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3898,6 +3898,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@repeaterjs/repeater": {
       "version": "3.0.4",
       "dev": true,
@@ -11472,6 +11480,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
+      "dependencies": {
+        "@remix-run/router": "1.15.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
+      "dependencies": {
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -13545,7 +13583,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
         "@types/react": "^18.2.15",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import reactLogo from './assets/react.svg';
 import viteLogo from '/vite.svg';
 import './App.css';
+import { Link } from 'react-router-dom';
 
 function App() {
   const [count, setCount] = useState('');
@@ -29,9 +30,7 @@ function App() {
       <div className="card">
         <button onClick={onClick}>count is {count ? count : 'unknown'}</button>
         <p>
-          <p>Dana was here</p>
-          <code>src/App.tsx</code> and save to test HMR
-          Farha Alsada <code>src/App.tsx</code> and save to test HMR
+          <Link to="/test"> Test page </Link>
         </p>
         <p> Sayed Ahmed was here </p>
       </div>

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -2,9 +2,24 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import TestPage from './pages/TestPage.tsx';
+
+// Place pages here
+const router = createBrowserRouter([
+  {
+    path: '/',
+    Component: App,
+  },
+  {
+    path: '/test',
+    Component: TestPage,
+  },
+]);
+// TODO: handle not found pages
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 );

--- a/packages/frontend/src/pages/TestPage.tsx
+++ b/packages/frontend/src/pages/TestPage.tsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom';
+
+function TestPage() {
+  return (
+    <>
+      <h2> This is a test page</h2>
+      <Link to="/"> Back </Link>
+    </>
+  );
+}
+
+export default TestPage;


### PR DESCRIPTION
This is a proposal to include `react-router` to enable client-side routing.

The PR currently installs the library, and adds example page to show how the library is used.

The use of this library is up for discussion. 