### PR TITLE
Add Lambda Functions Type-checking to CI/CD

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -30,3 +30,6 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npx sst build --stage prod
+    - name: Typecheck lambda functions
+      run: npm run typecheck
+      working-directory: ./packages/functions

--- a/.github/workflows/deploy-on-push-main.yaml
+++ b/.github/workflows/deploy-on-push-main.yaml
@@ -31,3 +31,6 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npx sst deploy --stage prod
+    - name: Typecheck lambda functions
+      run: npm run typecheck
+      working-directory: ./packages/functions


### PR DESCRIPTION
With the current workflow, the build check doesn't include type-checking the lambda functions.  (front-end code is type-checked though.)