### PR TITLE
Listening + Speaking UI Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-circular-progressbar": "^2.1.0",
         "react-icons": "^5.2.0",
         "react-router-dom": "^6.23.0",
+        "react-use-audio-player": "^2.2.0",
         "recordrtc": "^5.6.2"
       },
       "devDependencies": {
@@ -13450,6 +13451,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/howler": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz",
+      "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w=="
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "dev": true,
@@ -15530,6 +15536,17 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-use-audio-player": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-use-audio-player/-/react-use-audio-player-2.2.0.tgz",
+      "integrity": "sha512-IMM+WiZAq1KUvTwq0sAdRdjEzyG4jzz1tK/JtC/+LLt3z/uJk3AFRLL3pgbOgS/2SnfVzFKCxR7pnBsu6nUFvg==",
+      "dependencies": {
+        "howler": "^2.2.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/react-use-websocket": {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
     "@fontsource/inter": "^5.0.18",
     "aws-jwt-verify": "^4.0.1",
     "node-fetch": "^3.3.2",
+    "react-audio-player": "^0.17.0",
     "react-circular-progressbar": "^2.1.0",
     "react-icons": "^5.2.0",
-    "react-audio-player": "^0.17.0",
     "react-router-dom": "^6.23.0",
+    "react-use-audio-player": "^2.2.0",
     "recordrtc": "^5.6.2"
   }
 }

--- a/packages/frontend/src/components/ListeningAudioPlayer.tsx
+++ b/packages/frontend/src/components/ListeningAudioPlayer.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from 'react';
+import { useGlobalAudioPlayer } from 'react-use-audio-player';
+import { ProgressBar } from './ProgressBar';
+
+/** Audio bar for playing listening parts
+ *
+ * This component is also responsible for fetching and playing the audio
+ */
+export const ListeningAudioPlayer = ({ urls }: { urls: string[] }) => {
+  // const {} = useAudioPlayer();
+  const [trackIndex, setTrackIndex] = useState(0);
+
+  const audioPlayer = useGlobalAudioPlayer();
+  const pos = useAudioTime(audioPlayer.getPosition);
+
+  useEffect(() => {
+    audioPlayer.load(urls[trackIndex], {
+      onload: () => {
+        setTimeout(() => audioPlayer.play(), 3000);
+      },
+      onend: () => {
+        if (trackIndex < urls.length - 1) {
+          setTrackIndex(trackIndex + 1);
+        }
+      },
+    });
+  }, [trackIndex]);
+  // useEffect(() => {
+  //   audioPlayer.load(urls[trackIndex], {
+  //     autoplay: true,
+  //     onend: () => setTrackIndex(trackIndex + 1),
+  //   });
+  //   return cleanup;
+  // }, [trackIndex, load]);
+
+  return (
+    <div className="h-full w-full flex flex-row items-center px-4">
+      <span className="px-4" onClick={() => audioPlayer.seek(1000)}>
+        Part {trackIndex + 1}
+      </span>
+      <div className="flex-grow px-4">
+        <ProgressBar percentage={pos / audioPlayer.duration} />
+      </div>
+    </div>
+  );
+
+  // return (
+  //   <div>
+  //     <span>Part {trackIndex + 1} | </span>
+  //     <span>
+  //       pos: {pos}, dur: {audioPlayer.duration}, percentage:{' '}
+  //       {pos / audioPlayer.duration}
+  //     </span>
+  //   </div>
+  // );
+};
+
+/* Adapted from "Recipe: Syncing React state to live audio position"
+ * see https://www.npmjs.com/package/react-use-audio-player
+ */
+function useAudioTime(getPosition: () => number) {
+  const frameRef = useRef<number>();
+  const [pos, setPos] = useState(0);
+
+  useEffect(() => {
+    const animate = () => {
+      setPos(getPosition());
+      frameRef.current = requestAnimationFrame(animate);
+    };
+
+    frameRef.current = window.requestAnimationFrame(animate);
+
+    return () => {
+      if (frameRef.current) {
+        cancelAnimationFrame(frameRef.current);
+      }
+    };
+  }, [getPosition]);
+
+  return pos;
+}

--- a/packages/frontend/src/components/MicButton.tsx
+++ b/packages/frontend/src/components/MicButton.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { BsFillMicFill, BsFillMicMuteFill } from 'react-icons/bs';
+
+type MicButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const MicButton: React.FC<MicButtonProps> = ({
+  className,
+  ...props
+}) => {
+  const [isOn, setOn] = useState(false);
+  const size = 28;
+
+  const icon = isOn ? (
+    <BsFillMicFill size={size} />
+  ) : (
+    <BsFillMicMuteFill size={size} />
+  );
+  const style = isOn ? 'bg-red-400' : 'bg-white';
+
+  return (
+    <button
+      {...props}
+      className={`${className} inline-block ${style} p-4 rounded-full border-2 transition-all duration-200`}
+      onClick={() => setOn(x => !x)}
+    >
+      {icon}
+    </button>
+  );
+};

--- a/packages/frontend/src/components/ProgressBar.tsx
+++ b/packages/frontend/src/components/ProgressBar.tsx
@@ -1,0 +1,14 @@
+export const ProgressBar = ({ percentage = 0, isAnimated = false }) => {
+  const width = (percentage * 100).toFixed(2) + '%';
+
+  return (
+    <div className="bg-blue-1 flex rounded-xl">
+      <div
+        className={`bg-blue-4 inline-block h-4 rounded-xl ${
+          isAnimated ? 'transition-all duration-500' : ''
+        }`}
+        style={{ minWidth: width }}
+      ></div>
+    </div>
+  );
+};

--- a/packages/frontend/src/components/Reading/DiagramCompletionQuestionComponent.tsx
+++ b/packages/frontend/src/components/Reading/DiagramCompletionQuestionComponent.tsx
@@ -54,7 +54,6 @@ export const DiagramCompletionQuestionComponent = ({
                 onChange={e =>
                   handleInputChange(subQuestionIndex, partIndex, e.target.value)
                 }
-                placeholder="answer"
                 className={`lr-input ${inputStyle}`}
                 disabled={showCorrectAnswer}
               />

--- a/packages/frontend/src/components/Reading/SummaryCompletionQuestionComponent.tsx
+++ b/packages/frontend/src/components/Reading/SummaryCompletionQuestionComponent.tsx
@@ -54,7 +54,6 @@ export const SummaryCompletionQuestionComponent = ({
             <>
               <input
                 type="text"
-                placeholder="answer"
                 value={answer[subQuestionIndex][partIndex]}
                 onChange={e =>
                   handleInputChange(subQuestionIndex, partIndex, e.target.value)

--- a/packages/frontend/src/components/Reading/TableCompletionQuestionComponent.tsx
+++ b/packages/frontend/src/components/Reading/TableCompletionQuestionComponent.tsx
@@ -45,7 +45,6 @@ export const TableCompletionQuestionComponent = ({
             <>
               <input
                 type="text"
-                placeholder="answer"
                 value={studentAnswer}
                 onChange={event => handleInputChange(event, rowIndex, index)} // Handle input change
                 className={`lr-input ${inputStyle}`}

--- a/packages/frontend/src/components/TestComponents.tsx
+++ b/packages/frontend/src/components/TestComponents.tsx
@@ -1,0 +1,26 @@
+import { MouseEventHandler } from 'react';
+import { BsArrowLeft, BsCheckLg } from 'react-icons/bs';
+
+type TitleRowProps = {
+  title: string;
+  onSubmit?: MouseEventHandler;
+};
+
+export const TitleRow: React.FC<TitleRowProps> = ({ title, onSubmit }) => {
+  return (
+    <div className="w-full h-full flex items-center border-b-2">
+      <div className="w-1/3 h-full nav-item">
+        <button className="hover:text-gray-700">
+          <BsArrowLeft className="inline mr-2" />
+          <span>Back</span>
+        </button>
+      </div>
+      <div className="w-1/3 text-center font-light text-xl">{title}</div>
+      <div className="w-1/3 nav-item flex-row-reverse">
+        <button onClick={onSubmit}>
+          Submit <BsCheckLg className="inline" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -27,6 +27,8 @@ import { WritingPage } from './pages/WritingPage.tsx';
 import { writingSection } from './utilities.ts';
 import LRAnswersPage from './pages/LRAnswersPage.tsx';
 import React from 'react';
+import { SpeakingAudioPage } from './pages/SpeakingAudioPage.tsx';
+import { SpeakingCardPage } from './pages/SpeakingCardPage.tsx';
 
 Amplify.configure(
   {
@@ -158,6 +160,14 @@ const router = createBrowserRouter([
   {
     path: '/answers/:section/:sk', //TODO: we will remove this link because it will be added in another page
     Component: LRAnswersPage,
+  },
+  {
+    path: '/test-speaking-card-ui',
+    Component: SpeakingCardPage,
+  },
+  {
+    path: '/test-speaking-audio-ui',
+    Component: SpeakingAudioPage,
   },
   {
     path: '/PlacementTest',

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -29,6 +29,7 @@ import LRAnswersPage from './pages/LRAnswersPage.tsx';
 import React from 'react';
 import { SpeakingAudioPage } from './pages/SpeakingAudioPage.tsx';
 import { SpeakingCardPage } from './pages/SpeakingCardPage.tsx';
+import { ListeningQuestionsPage } from './pages/ListeningQuestionsPage.tsx';
 
 Amplify.configure(
   {
@@ -150,8 +151,12 @@ const router = createBrowserRouter([
   },
   // These pages don't use `Layout` yet
   {
-    path: '/:section/:sk', // Updated route with path parameters
+    path: '/reading/:sk',
     Component: ReadingQuestions,
+  },
+  {
+    path: '/listening/:sk',
+    Component: ListeningQuestionsPage,
   },
   {
     path: '/scores/:section/:sk', //TODO: we will remove this link because it will be added in another page

--- a/packages/frontend/src/pages/ListeningQuestionsPage.tsx
+++ b/packages/frontend/src/pages/ListeningQuestionsPage.tsx
@@ -1,0 +1,118 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { Answer } from '../utilities/LRUtilities';
+import { listeningParts } from '../utilities/LRSampleQuestions';
+import { TitleRow } from '../components/TestComponents';
+import {
+  QuestionsComponent,
+  initialAnswer,
+} from '../components/Reading/QuestionsComponent';
+import { useState } from 'react';
+import { toJSON } from '../utilities';
+import { post } from 'aws-amplify/api';
+import { BsQuestionLg } from 'react-icons/bs';
+
+type setType = (arg: Answer[]) => void;
+
+export const ListeningQuestionsPage = () => {
+  const { sk } = useParams();
+  if (!sk) return;
+
+  const navigate = useNavigate();
+
+  // TODO: this should be a parameter
+  const parts = listeningParts; //listeningParts
+
+  const [partIndex, setPartIndex] = useState(0);
+
+  const [answers, setAnswers] = useState<Answer[][]>(
+    parts.map(part => initialAnswer(part.Questions)),
+  );
+
+  const indexSet = function (i: number): setType {
+    return (value: Answer[]) => {
+      // console.log('Triggered with', { i, value });
+      const arrCopy = [...answers];
+      arrCopy[i] = value;
+      setAnswers(arrCopy);
+    };
+  };
+
+  const submitAnswers = async (sk: string) => {
+    try {
+      const payload = {
+        studentAnswers: answers, // Assuming 'answers' is the nested array data you showed
+      };
+      const response = await toJSON(
+        post({
+          apiName: 'myAPI',
+          path: `/answers/listening/${sk}`,
+          options: {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: payload,
+          },
+        }),
+      );
+      console.log('Submit response:', response);
+      alert('Answers submitted successfully!');
+      navigate(`/scores/listening/${sk}`);
+    } catch (error) {
+      console.error('Error submitting answers:', error);
+      alert('Failed to submit answers.');
+    }
+  };
+
+  /* Bar */
+  const linkStyling =
+    'px-3 lg:px-5 transition -colors duration-200 flex items-center leading-normal ';
+  const barContent = (
+    <div className="flex flex-1 h-full font-montserrat text-sm font-bold text-white">
+      <span className={linkStyling + ' hover-darken'}>
+        <span>Help</span>
+        <BsQuestionLg className="inline ml-2" size={16} />
+      </span>
+      <span className={linkStyling + ' mr-auto'}>00:10</span>
+      {parts.map((_, i) => (
+        <button
+          className={
+            linkStyling +
+            (i === partIndex ? 'bg-black bg-opacity-40' : 'hover-darken')
+          }
+          onClick={() => setPartIndex(i)}
+          key={i}
+        >
+          Part {i + 1}
+        </button>
+      ))}
+    </div>
+  );
+
+  const titleRow = (
+    <TitleRow title="Listening Test" onSubmit={() => submitAnswers(sk)} />
+  );
+
+  const questionsScreen = (
+    <div className="w-full h-full p-8 overflow-y-scroll">
+      <QuestionsComponent
+        questions={parts[partIndex].Questions}
+        answers={answers[partIndex]}
+        setAnswers={indexSet(partIndex)}
+        showCorrectAnswer={false}
+      />
+    </div>
+  );
+
+  return (
+    <>
+      <div className="h-[6svh] bg-blue-4">{barContent}</div>
+      <div className="h-[6svh] lg:h-[8svh]">{titleRow}</div>
+      <div
+        className={`flex fRex-col lg:flex-row
+          h-[88svh] lg:h-[86svh] w-screen bg-white`}
+      >
+        {questionsScreen}
+      </div>
+    </>
+  );
+};

--- a/packages/frontend/src/pages/ListeningQuestionsPage.tsx
+++ b/packages/frontend/src/pages/ListeningQuestionsPage.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import { toJSON } from '../utilities';
 import { post } from 'aws-amplify/api';
 import { BsQuestionLg } from 'react-icons/bs';
+import { ListeningAudioPlayer } from '../components/ListeningAudioPlayer';
 
 type setType = (arg: Answer[]) => void;
 
@@ -21,6 +22,12 @@ export const ListeningQuestionsPage = () => {
 
   // TODO: this should be a parameter
   const parts = listeningParts; //listeningParts
+  const urls = [
+    'https://s3.eu-west-2.amazonaws.com/ielts-web-static/production/Sample-tests/Listening/ielts-listening-sample-task-5-matching.mp3',
+    'https://s3.eu-west-2.amazonaws.com/ielts-web-static/production/Sample-tests/Listening/ielts-listening-sample-task-3-short-answer-questions.mp3',
+    'https://s3.eu-west-2.amazonaws.com/ielts-web-static/production/Sample-tests/Listening/ielts-listening-sample-task-1-form-completion.mp3',
+    'https://s3.eu-west-2.amazonaws.com/ielts-web-static/production/Sample-tests/Listening/ielts-listening-sample-task-8-note-completion.mp3',
+  ];
 
   const [partIndex, setPartIndex] = useState(0);
 
@@ -92,6 +99,9 @@ export const ListeningQuestionsPage = () => {
     <TitleRow title="Listening Test" onSubmit={() => submitAnswers(sk)} />
   );
 
+  /* Listening Audio */
+  const audioPlayer = <ListeningAudioPlayer urls={urls} />;
+
   const questionsScreen = (
     <div className="w-full h-full p-8 overflow-y-scroll">
       <QuestionsComponent
@@ -107,12 +117,10 @@ export const ListeningQuestionsPage = () => {
     <>
       <div className="h-[6svh] bg-blue-4">{barContent}</div>
       <div className="h-[6svh] lg:h-[8svh]">{titleRow}</div>
-      <div
-        className={`flex fRex-col lg:flex-row
-          h-[88svh] lg:h-[86svh] w-screen bg-white`}
-      >
+      <div className={`h-[82svh] lg:h-[80svh] w-screen bg-white`}>
         {questionsScreen}
       </div>
+      <div className="h-[6svh] bg-gray-200">{audioPlayer}</div>
     </>
   );
 };

--- a/packages/frontend/src/pages/ReadingQuestionsPage.tsx
+++ b/packages/frontend/src/pages/ReadingQuestionsPage.tsx
@@ -12,7 +12,12 @@ import {
   initialAnswer,
 } from '../components/Reading/QuestionsComponent';
 import { useParams, useNavigate } from 'react-router-dom';
-import { BsArrowLeft, BsCheckLg, BsChevronUp } from 'react-icons/bs';
+import {
+  BsArrowLeft,
+  BsCheckLg,
+  BsChevronUp,
+  BsQuestionLg,
+} from 'react-icons/bs';
 
 type setType = (arg: Answer[]) => void;
 
@@ -69,9 +74,13 @@ const ReadingQuestions = () => {
 
   /* Bar */
   const linkStyling =
-    'px-5 transition-colors duration-200 flex items-center leading-normal ';
+    'px-3 lg:px-5 transition -colors duration-200 flex items-center leading-normal ';
   const barContent = (
     <div className="flex flex-1 h-full font-montserrat text-sm font-bold text-white">
+      <span className={linkStyling + ' hover-darken'}>
+        <span>Help</span>
+        <BsQuestionLg className="inline ml-2" size={16} />
+      </span>
       <span className={linkStyling + ' mr-auto'}>00:10</span>
       {parts.map((_, i) => (
         <button

--- a/packages/frontend/src/pages/ReadingQuestionsPage.tsx
+++ b/packages/frontend/src/pages/ReadingQuestionsPage.tsx
@@ -12,7 +12,7 @@ import {
   initialAnswer,
 } from '../components/Reading/QuestionsComponent';
 import { useParams, useNavigate } from 'react-router-dom';
-import { BsChevronUp } from 'react-icons/bs';
+import { BsArrowLeft, BsCheckLg, BsChevronUp } from 'react-icons/bs';
 
 type setType = (arg: Answer[]) => void;
 
@@ -71,10 +71,10 @@ const ReadingQuestions = () => {
   const linkStyling =
     'px-5 transition-colors duration-200 flex items-center leading-normal ';
   const barContent = (
-    <div className="flex flex-1 h-full font-montserrat text-md font-bold text-white">
+    <div className="flex flex-1 h-full font-montserrat text-sm font-bold text-white">
       <span className={linkStyling + ' mr-auto'}>00:10</span>
       <button
-        className={linkStyling + 'hover:bg-black hover:bg-opacity-10'}
+        className={'nav-item hover-darken'}
         onClick={() => submitAnswers(sk)}
       >
         Submit Answers
@@ -83,9 +83,7 @@ const ReadingQuestions = () => {
         <button
           className={
             linkStyling +
-            (i === partIndex
-              ? 'bg-black bg-opacity-40'
-              : 'hover:bg-black hover:bg-opacity-10')
+            (i === partIndex ? 'bg-black bg-opacity-40' : 'hover-darken')
           }
           onClick={() => setPartIndex(i)}
           key={i}
@@ -95,6 +93,24 @@ const ReadingQuestions = () => {
       ))}
     </div>
   );
+
+  const titleRow = (
+    <div className="w-full h-full flex items-center">
+      <div className="w-1/3 h-full nav-item">
+        <button className="hover:text-gray-700">
+          <BsArrowLeft className="inline mr-2" />
+          <span>Back</span>
+        </button>
+      </div>
+      <div className="w-1/3 text-center font-light text-lg">Reading Test</div>
+      <div className="w-1/3 nav-item flex-row-reverse">
+        <button>
+          Submit <BsCheckLg className="inline" />
+        </button>
+      </div>
+    </div>
+  );
+  // const titleRow = null;
 
   /* Maximize */
   const maximizeButton = (
@@ -164,7 +180,8 @@ const ReadingQuestions = () => {
   return (
     <>
       <div className="h-[6svh] bg-blue-4">{barContent}</div>
-      <div className="flex flex-col lg:flex-row h-[94svh] w-screen overflow-y-hidden">
+      <div className="h-[6svh] lg:h-[8svh]">{titleRow}</div>
+      <div className="flex flex-col lg:flex-row h-[88svh] lg:h-[86svh] w-screen overflow-y-hidden">
         <div className={passageContainerStyle}>{passageScreen}</div>
         <div className={questionsContainerStyle}>{questionsScreen}</div>
       </div>

--- a/packages/frontend/src/pages/ReadingQuestionsPage.tsx
+++ b/packages/frontend/src/pages/ReadingQuestionsPage.tsx
@@ -73,12 +73,6 @@ const ReadingQuestions = () => {
   const barContent = (
     <div className="flex flex-1 h-full font-montserrat text-sm font-bold text-white">
       <span className={linkStyling + ' mr-auto'}>00:10</span>
-      <button
-        className={'nav-item hover-darken'}
-        onClick={() => submitAnswers(sk)}
-      >
-        Submit Answers
-      </button>
       {parts.map((_, i) => (
         <button
           className={
@@ -95,16 +89,16 @@ const ReadingQuestions = () => {
   );
 
   const titleRow = (
-    <div className="w-full h-full flex items-center">
+    <div className="w-full h-full flex items-center max-md:border-b-2">
       <div className="w-1/3 h-full nav-item">
         <button className="hover:text-gray-700">
           <BsArrowLeft className="inline mr-2" />
           <span>Back</span>
         </button>
       </div>
-      <div className="w-1/3 text-center font-light text-lg">Reading Test</div>
+      <div className="w-1/3 text-center font-light text-xl">Reading Test</div>
       <div className="w-1/3 nav-item flex-row-reverse">
-        <button>
+        <button onClick={() => submitAnswers(sk)}>
           Submit <BsCheckLg className="inline" />
         </button>
       </div>

--- a/packages/frontend/src/pages/ReadingQuestionsPage.tsx
+++ b/packages/frontend/src/pages/ReadingQuestionsPage.tsx
@@ -12,12 +12,8 @@ import {
   initialAnswer,
 } from '../components/Reading/QuestionsComponent';
 import { useParams, useNavigate } from 'react-router-dom';
-import {
-  BsArrowLeft,
-  BsCheckLg,
-  BsChevronUp,
-  BsQuestionLg,
-} from 'react-icons/bs';
+import { BsChevronUp, BsQuestionLg } from 'react-icons/bs';
+import { TitleRow } from '../components/TestComponents';
 
 type setType = (arg: Answer[]) => void;
 
@@ -98,22 +94,8 @@ const ReadingQuestions = () => {
   );
 
   const titleRow = (
-    <div className="w-full h-full flex items-center max-md:border-b-2">
-      <div className="w-1/3 h-full nav-item">
-        <button className="hover:text-gray-700">
-          <BsArrowLeft className="inline mr-2" />
-          <span>Back</span>
-        </button>
-      </div>
-      <div className="w-1/3 text-center font-light text-xl">Reading Test</div>
-      <div className="w-1/3 nav-item flex-row-reverse">
-        <button onClick={() => submitAnswers(sk)}>
-          Submit <BsCheckLg className="inline" />
-        </button>
-      </div>
-    </div>
+    <TitleRow title="Reading Test" onSubmit={() => submitAnswers(sk)} />
   );
-  // const titleRow = null;
 
   /* Maximize */
   const maximizeButton = (
@@ -177,7 +159,7 @@ const ReadingQuestions = () => {
     containerStyles + ' ' + (isMaximized ? 'max-h-[100%]' : 'max-h-[50%]');
   const questionsContainerStyle =
     containerStyles +
-    ' bg-white rounded-3xl ' +
+    ' bg-white ' +
     (isMaximized ? 'max-h-[0%]' : 'max-h-[50%]');
 
   return (

--- a/packages/frontend/src/pages/SpeakingAudioPage.tsx
+++ b/packages/frontend/src/pages/SpeakingAudioPage.tsx
@@ -1,0 +1,3 @@
+export const SpeakingAudioPage = () => {
+  return <></>;
+};

--- a/packages/frontend/src/pages/SpeakingCardPage.tsx
+++ b/packages/frontend/src/pages/SpeakingCardPage.tsx
@@ -1,0 +1,3 @@
+export const SpeakingCardPage = () => {
+  return <></>;
+};

--- a/packages/frontend/src/pages/SpeakingCardPage.tsx
+++ b/packages/frontend/src/pages/SpeakingCardPage.tsx
@@ -1,6 +1,10 @@
+import { BsQuestionLg } from 'react-icons/bs';
 import { MicButton } from '../components/MicButton';
+import { TitleRow } from '../components/TestComponents';
 
 export const SpeakingCardPage = () => {
+  const partIndex = 1;
+  const parts = ['', '', ''];
   const q = {
     task: {
       text: 'Describe your favorite shopping center.',
@@ -14,9 +18,34 @@ export const SpeakingCardPage = () => {
     ],
   };
 
+  /* Bar */
+  const linkStyling =
+    'px-3 lg:px-5 transition -colors duration-200 flex items-center leading-normal ';
+  const barContent = (
+    <div className="flex flex-1 h-full font-montserrat text-sm font-bold text-white">
+      <span className={linkStyling + ' hover-darken'}>
+        <span>Help</span>
+        <BsQuestionLg className="inline ml-2" size={16} />
+      </span>
+      <span className={linkStyling + ' mr-auto'}>00:10</span>
+      {parts.map((_, i) => (
+        <button
+          className={
+            linkStyling + (i === partIndex ? 'bg-black bg-opacity-40' : '')
+          }
+          key={i}
+        >
+          Part {i + 1}
+        </button>
+      ))}
+    </div>
+  );
+
+  const titleRow = <TitleRow title="Speaking" />;
+
   const cardContent = (
     <>
-      <h3 className="font-light text-lg mb-3">{q.task.text}</h3>
+      <h3 className="font-light text-lg mb-3 border-b-2">{q.task.text}</h3>
       <ul className="list-inside ml-4">
         {q.questions.map((question, index) => (
           <li key={index} className="list-disc mb-1">
@@ -27,14 +56,20 @@ export const SpeakingCardPage = () => {
     </>
   );
 
+  const pageBody = (
+    <div className="flex flex-col h-full justify-evenly items-center px-6">
+      <div className="w-full max-w-xl h-60 bg-white rounded-xl shadow-backdrop py-4 px-6">
+        {cardContent}
+      </div>
+      <MicButton className="shadow-backdrop" />
+    </div>
+  );
+
   return (
     <>
-      <div className="flex flex-col justify-between items-center h-svh">
-        <div className="w-full max-w-xl h-60 bg-white rounded-xl shadow-backdrop py-4 px-6">
-          {cardContent}
-        </div>
-        <MicButton className="shadow-backdrop" />
-      </div>
+      <div className="h-[6svh] bg-blue-4">{barContent}</div>
+      <div className="h-[6svh] lg:h-[8svh]">{titleRow}</div>
+      <div className="h-[82svh] lg:h-[80svh] w-screen">{pageBody}</div>
     </>
   );
 };

--- a/packages/frontend/src/pages/SpeakingCardPage.tsx
+++ b/packages/frontend/src/pages/SpeakingCardPage.tsx
@@ -1,3 +1,40 @@
+import { MicButton } from '../components/MicButton';
+
 export const SpeakingCardPage = () => {
-  return <></>;
+  const q = {
+    task: {
+      text: 'Describe your favorite shopping center.',
+    },
+    questions: [
+      'Where is this center?',
+      'What is special about it?',
+      'What do you do when you go there?',
+      'What do people say about it?',
+      'Explain why you think it is a good choice.',
+    ],
+  };
+
+  const cardContent = (
+    <>
+      <h3 className="font-light text-lg mb-3">{q.task.text}</h3>
+      <ul className="list-inside ml-4">
+        {q.questions.map((question, index) => (
+          <li key={index} className="list-disc mb-1">
+            {question}
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+
+  return (
+    <>
+      <div className="flex flex-col justify-between items-center h-svh">
+        <div className="w-full max-w-xl h-60 bg-white rounded-xl shadow-backdrop py-4 px-6">
+          {cardContent}
+        </div>
+        <MicButton className="shadow-backdrop" />
+      </div>
+    </>
+  );
 };

--- a/packages/frontend/src/pages/sections.tsx
+++ b/packages/frontend/src/pages/sections.tsx
@@ -24,6 +24,14 @@ const sections = () => (
         <Button label="Speaking" />
       </Link>
     </div>
+    <div className="flex mt-6">
+      <Link to="/test-speaking-audio-ui">
+        <Button label="Speaking Audio UI" />
+      </Link>
+      <Link to="/test-speaking-card-ui">
+        <Button label="Speaking Card UI" />
+      </Link>
+    </div>
   </>
 );
 


### PR DESCRIPTION
### Speaking

- Speaking task 1 and task 3 will be in SpeakingAudioPage         
- Speaking task 2 will be in SpeakingCardPage                     

For now I started with speaking card page.  I put in place the general layout of the page.

### Listening

I used [react-use-audio-player](https://www.npmjs.com/package/react-use-audio-player).  I adapted some of their code to work.

For now, all of the audio tracks will auto play, with a 5 seconds delay gap between them (negotiable).

Note that I hard coded the urls for now, and some of the include instructions on delays and number of questions.  As far as I can tell there are no listening audio yet in the database.  So someone has to sort this out (#194).

