### PR TITLE
Fulltest feedback functionality -- Integrate front-end w/ back-end

### DIFF
--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -7,19 +7,21 @@ import { Spinner } from './Spinner';
 import { useNavigate, useParams } from 'react-router-dom';
 import { WSFeedbackComponent } from './WSFeedback';
 
-type Screens = 'feedback' | 'listening' | 'reading' | 'writing' | 'speaking';
+type Screens = 'general' | 'listening' | 'reading' | 'writing' | 'speaking';
 type DataType = { fullItem: FullTestItem } | undefined | { message: string };
 
 export const AllFeedbacks: React.FC = () => {
-  const [data, setData] = useState<DataType>();
-  const [screen, setScreen] = useState<Screens>('feedback');
+  let out;
 
+  const [data, setData] = useState<DataType>();
+  const [screen, setScreen] = useState<Screens>('general');
+
+  // Get full test item
   const { sk } = useParams();
   const navigate = useNavigate();
   if (!sk) {
     navigate(-1);
   }
-
   useEffect(() => {
     console.log(`/fullTestFeedback/${sk}`);
     toJSON(
@@ -38,19 +40,20 @@ export const AllFeedbacks: React.FC = () => {
       });
   }, []);
 
-  let out;
-
   if (!data) {
     return <Spinner message={'Loading your feedback'} />;
   }
-  // return JSON.stringify(fullTestItem);
 
   if ('message' in data) {
+    // TODO: error page
     return `Recieved error: ${data.message}`;
   }
 
+  console.log({ data });
+
+  // Handle various pages
   switch (screen) {
-    case 'feedback':
+    case 'general':
       const readingFeedback = data.fullItem.readingAnswer?.feedback;
       const readingScores =
         readingFeedback && 'scores' in readingFeedback
@@ -103,9 +106,9 @@ export const AllFeedbacks: React.FC = () => {
   return (
     <>
       {out}
-      {screen !== 'feedback' && (
+      {screen !== 'general' && (
         <div className="mt-20">
-          <Button onClick={() => setScreen('feedback')}>Back</Button>
+          <Button onClick={() => setScreen('general')}>Back</Button>
         </div>
       )}
     </>

--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -1,36 +1,103 @@
 import React, { useEffect, useState } from 'react';
 import { FullTestItem } from '../../../functions/src/utilities/fullTestUtilities';
-import { post } from 'aws-amplify/api';
+import { Button } from './Button';
+import { get } from 'aws-amplify/api';
 import { toJSON } from '../utilities';
 import { Spinner } from './Spinner';
+import { useNavigate, useParams } from 'react-router-dom';
+import { WSFeedbackComponent } from './WSFeedback';
+
+type Screens = 'feedback' | 'listening' | 'reading' | 'writing' | 'speaking';
+type DataType = FullTestItem | undefined | { message: string };
 
 export const AllFeedbacks: React.FC = () => {
-  const [fullTestItem, setFullTestItem] = useState<
-    FullTestItem | undefined | null
-  >();
+  const [data, setData] = useState<DataType>();
+  const [screen, setScreen] = useState<Screens>('feedback');
+
+  const { sk } = useParams();
+  const navigate = useNavigate();
+  if (!sk) {
+    navigate(-1);
+  }
 
   useEffect(() => {
-    const getData = async () => {
-      const response = await toJSON(
-        post({
-          apiName: 'myAPI',
-          path: '/',
-        }),
-      );
-
-      setFullTestItem(response);
-    };
-    getData();
-    // return () => {};
+    console.log(`/fullTestFeedback/${sk}`);
+    toJSON(
+      get({
+        apiName: 'myAPI',
+        path: `/fullTestFeedback/${sk}`,
+      }),
+    )
+      .then(response => setData(response))
+      .catch(err => {
+        if ('message' in err) {
+          setData(err);
+        } else {
+          throw err;
+        }
+      });
   }, []);
 
   let out;
 
-  if (fullTestItem === undefined) {
-    out = <Spinner message={'Loading your feedback'} />;
-  } else {
-    out = JSON.stringify(fullTestItem);
+  if (!data) {
+    return <Spinner message={'Loading your feedback'} />;
+  }
+  // return JSON.stringify(fullTestItem);
+
+  if ('message' in data) {
+    return `Recieved error: ${data.message}`;
   }
 
-  return out;
+  switch (screen) {
+    case 'feedback':
+      out = (
+        <div>
+          <h3 className="text-lg font-light">Feedback</h3>
+          <div>
+            <Button onClick={() => setScreen('listening')}>
+              Listening Feedback
+            </Button>
+            <Button onClick={() => setScreen('reading')}>
+              Reading Feedback
+            </Button>
+            <Button onClick={() => setScreen('writing')}>
+              Writing Feedback
+            </Button>
+            <Button onClick={() => setScreen('speaking')}>
+              Speaking Feedback
+            </Button>
+          </div>
+        </div>
+      );
+      break;
+
+    case 'listening':
+      out = 'Listening';
+      break;
+
+    case 'reading':
+      out = 'reading';
+      break;
+
+    case 'writing':
+      const feedback = data?.writingAnswer?.feedback;
+      if (!feedback) break;
+      out = <WSFeedbackComponent feedback={feedback[0]} />;
+      break;
+
+    case 'speaking':
+      break;
+  }
+
+  return (
+    <>
+      {out}
+      {screen !== 'feedback' && (
+        <div className="mt-20">
+          <Button onClick={() => setScreen('feedback')}>Back</Button>
+        </div>
+      )}
+    </>
+  );
 };

--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { FullTestItem } from '../../../functions/src/utilities/fullTestUtilities';
+import { post } from 'aws-amplify/api';
+import { toJSON } from '../utilities';
+import { Spinner } from './Spinner';
+
+export const AllFeedbacks: React.FC = () => {
+  const [fullTestItem, setFullTestItem] = useState<
+    FullTestItem | undefined | null
+  >();
+
+  useEffect(() => {
+    const getData = async () => {
+      const response = await toJSON(
+        post({
+          apiName: 'myAPI',
+          path: '/',
+        }),
+      );
+
+      setFullTestItem(response);
+    };
+    getData();
+    // return () => {};
+  }, []);
+
+  let out;
+
+  if (fullTestItem === undefined) {
+    out = <Spinner message={'Loading your feedback'} />;
+  } else {
+    out = JSON.stringify(fullTestItem);
+  }
+
+  return out;
+};

--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -6,6 +6,7 @@ import { toJSON } from '../utilities';
 import { Spinner } from './Spinner';
 import { useNavigate, useParams } from 'react-router-dom';
 import { WSFeedbackComponent } from './WSFeedback';
+import LAnswersPage from '../pages/LAnswersPage';
 
 type Screens = 'general' | 'listening' | 'reading' | 'writing' | 'speaking';
 type DataType = { fullItem: FullTestItem } | undefined | { message: string };
@@ -52,11 +53,12 @@ export const AllFeedbacks: React.FC = () => {
   console.log({ data });
 
   // Handle various pages
+  const listeningFeedback = data.fullItem?.listeningAnswer?.feedback;
+  const readingFeedback = data.fullItem.readingAnswer?.feedback;
   switch (screen) {
     case 'general':
-      const readingFeedback = data.fullItem.readingAnswer?.feedback;
       const readingScores =
-        readingFeedback && 'scores' in readingFeedback
+        readingFeedback && !('error' in readingFeedback)
           ? readingFeedback.totalScore
           : null;
 
@@ -84,11 +86,18 @@ export const AllFeedbacks: React.FC = () => {
       break;
 
     case 'listening':
-      out = 'Listening';
+      if (listeningFeedback && !('error' in listeningFeedback)) {
+        console.log(listeningFeedback.studentAnswers);
+        out = (
+          <LAnswersPage studentAnswers={listeningFeedback.studentAnswers} />
+        );
+      } else {
+        out = `Listening error: ${listeningFeedback?.error}`;
+      }
+
       break;
 
     case 'reading':
-      out = 'reading';
       break;
 
     case 'writing':

--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -8,7 +8,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { WSFeedbackComponent } from './WSFeedback';
 
 type Screens = 'feedback' | 'listening' | 'reading' | 'writing' | 'speaking';
-type DataType = FullTestItem | undefined | { message: string };
+type DataType = { fullItem: FullTestItem } | undefined | { message: string };
 
 export const AllFeedbacks: React.FC = () => {
   const [data, setData] = useState<DataType>();
@@ -51,10 +51,18 @@ export const AllFeedbacks: React.FC = () => {
 
   switch (screen) {
     case 'feedback':
+      const readingFeedback = data.fullItem.readingAnswer?.feedback;
+      const readingScores =
+        readingFeedback && 'scores' in readingFeedback
+          ? readingFeedback.totalScore
+          : null;
+
       out = (
         <div>
           <h3 className="text-lg font-light">Feedback</h3>
           <div>
+            <p>Reading score: {JSON.stringify(readingScores)}</p>
+            <div className="mt-4"></div>
             <Button onClick={() => setScreen('listening')}>
               Listening Feedback
             </Button>
@@ -81,9 +89,11 @@ export const AllFeedbacks: React.FC = () => {
       break;
 
     case 'writing':
-      const feedback = data?.writingAnswer?.feedback;
+      const feedback = data.fullItem?.writingAnswer?.feedback;
       if (!feedback) break;
-      out = <WSFeedbackComponent feedback={feedback[0]} />;
+      out = feedback.map((taskFeedback, key) => (
+        <WSFeedbackComponent feedback={taskFeedback} key={key} />
+      ));
       break;
 
     case 'speaking':

--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -110,7 +110,10 @@ export const AllFeedbacks: React.FC = () => {
       if (listeningFeedback && !('error' in listeningFeedback)) {
         console.log(listeningFeedback.studentAnswers);
         out = (
-          <LAnswersPage studentAnswers={listeningFeedback.studentAnswers} />
+          <LAnswersPage
+            studentAnswers={listeningFeedback.studentAnswers}
+            onBack={() => setScreen('general')}
+          />
         );
       } else {
         out = <Layout>{`Listening error: ${listeningFeedback?.error}`}</Layout>;

--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -8,6 +8,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { WSFeedbackComponent } from './WSFeedback';
 import LAnswersPage from '../pages/LAnswersPage';
 import { Layout } from '../Layout';
+import RAnswersPage from '../pages/RAnswersPage';
 
 type Screens = 'general' | 'listening' | 'reading' | 'writing' | 'speaking';
 type DataType = { fullItem: FullTestItem } | undefined | { message: string };
@@ -76,6 +77,8 @@ export const AllFeedbacks: React.FC = () => {
   // Handle various pages
   const listeningFeedback = data.fullItem?.listeningAnswer?.feedback;
   const readingFeedback = data.fullItem.readingAnswer?.feedback;
+  const readingSection = data.fullItem.questions.reading;
+
   switch (screen) {
     case 'general':
       const readingScores =
@@ -118,10 +121,25 @@ export const AllFeedbacks: React.FC = () => {
       } else {
         out = <Layout>{`Listening error: ${listeningFeedback?.error}`}</Layout>;
       }
-
       break;
 
     case 'reading':
+      if (readingFeedback && !('error' in readingFeedback)) {
+        console.log(readingFeedback.studentAnswers);
+        out = (
+          <RAnswersPage
+            readingParts={[
+              readingSection.P1,
+              readingSection.P2,
+              readingSection.P3,
+            ]}
+            studentAnswers={readingFeedback.studentAnswers}
+            onBack={() => setScreen('general')}
+          />
+        );
+      } else {
+        out = <Layout>{`Listening error: ${readingFeedback?.error}`}</Layout>;
+      }
       break;
 
     case 'writing':

--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -25,13 +25,29 @@ export const AllFeedbacks: React.FC = () => {
   }
   useEffect(() => {
     console.log(`/fullTestFeedback/${sk}`);
+
+    // Local was found
+    try {
+      let localData = getCachedFeedback(sk as string);
+      if (localData) {
+        setData(localData);
+        return;
+      }
+    } catch (e) {
+      console.error(e);
+    }
+
+    // Corrupt or no local data was found
     toJSON(
       get({
         apiName: 'myAPI',
         path: `/fullTestFeedback/${sk}`,
       }),
     )
-      .then(response => setData(response))
+      .then(response => {
+        setData(response);
+        setCachedFeedback(response, sk as string);
+      })
       .catch(err => {
         if ('message' in err) {
           setData(err);
@@ -122,4 +138,16 @@ export const AllFeedbacks: React.FC = () => {
       )}
     </>
   );
+};
+
+const getFeedbackKey = (testId: string) => `FeedbackItem-${testId}`;
+
+const getCachedFeedback = (testId: string) => {
+  const localData = sessionStorage.getItem(getFeedbackKey(testId));
+  if (localData) console.log('Using cached', { localData });
+  return localData ? JSON.parse(localData) : localData;
+};
+
+export const setCachedFeedback = (feedback: any, testId: string) => {
+  sessionStorage.setItem(getFeedbackKey(testId), JSON.stringify(feedback));
 };

--- a/packages/frontend/src/pages/FullTestPage.tsx
+++ b/packages/frontend/src/pages/FullTestPage.tsx
@@ -10,6 +10,7 @@ import { Spinner } from '../components/Spinner';
 import { WritingPage } from './WritingPage';
 import { IntermediatePage } from '../components/IntermediatePage';
 import { ToastContainer, toast } from 'react-toastify';
+import { setCachedFeedback } from '../components/AllFeedbacks';
 
 export const FullTestPage = () => {
   let out;
@@ -62,6 +63,17 @@ export const FullTestPage = () => {
 
         toast.dismiss();
         setIsloading(false);
+      } else if ('fullItem' in response) {
+        console.log('Recieved fullItem', response);
+
+        // setState(response);
+        toast('Recieved Feedback');
+        setTimeout(() => {
+          navigate(`/feedback/${testId}`);
+        }, 1000);
+        setCachedFeedback(response, testId as string);
+      } else {
+        console.log('Unexpected payload');
       }
 
       // Message timeout
@@ -174,7 +186,9 @@ export const FullTestPage = () => {
       }
 
       // Question was returned
-      else {
+      else if ('fullItem' in state) {
+        return JSON.stringify(state);
+      } else {
         let dummySubmit: any;
         const time = Number(testId.slice(0, testId.indexOf('-')));
         const savedAnswers = state.data?.answer?.answer;

--- a/packages/frontend/src/pages/LAnswersPage.tsx
+++ b/packages/frontend/src/pages/LAnswersPage.tsx
@@ -1,45 +1,17 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import '../stylesheets/readingStyling.css';
 import '../stylesheets/exam.css';
 import { listeningParts } from '../utilities/LRSampleQuestions';
-import { get } from 'aws-amplify/api';
-import { toJSON } from '../utilities';
 
 import { QuestionsComponent } from '../components/Reading/QuestionsComponent';
-import { useParams } from 'react-router-dom';
 import { BsArrowLeft, BsQuestionLg } from 'react-icons/bs';
-//import WaveSurferPlayer from '../components/ListeningAudioPlayer';
 
-const LAnswersPage = () => {
-  const { sk } = useParams<{
-    sk: string | undefined;
-  }>();
-  const [data, setData] = useState<any>(null);
+type LAnswersPageProps = {
+  studentAnswers: any;
+};
+
+const LAnswersPage: React.FC<LAnswersPageProps> = ({ studentAnswers }) => {
   const [partIndex, setPartIndex] = useState(0);
-
-  useEffect(() => {
-    if (!sk) return;
-    console.log(' sk: ', sk);
-    toJSON(
-      get({
-        apiName: 'myAPI',
-        path: `/scores/listening/${sk}`,
-      }),
-    )
-      .then(data => {
-        setData(data);
-        console.log('data: ', data);
-      })
-      .catch(error => {
-        console.error(error);
-      });
-  }, [sk]);
-
-  if (!data) {
-    return (
-      <div className="text-lg px-10 text-center mb-8 mt-6">Loading...</div>
-    );
-  }
 
   // TODO: this should be a parameter
   const parts = listeningParts;
@@ -98,8 +70,8 @@ const LAnswersPage = () => {
     <div className="w-full h-full p-8 overflow-y-scroll">
       <QuestionsComponent
         questions={parts[partIndex].Questions}
-        answers={data.studentAnswers[partIndex]}
-        setAnswers={data.studentAnswers[partIndex]}
+        answers={studentAnswers[partIndex]}
+        setAnswers={() => {}}
         showCorrectAnswer={true}
       />
     </div>

--- a/packages/frontend/src/pages/LAnswersPage.tsx
+++ b/packages/frontend/src/pages/LAnswersPage.tsx
@@ -8,9 +8,13 @@ import { BsArrowLeft, BsQuestionLg } from 'react-icons/bs';
 
 type LAnswersPageProps = {
   studentAnswers: any;
+  onBack: () => void;
 };
 
-const LAnswersPage: React.FC<LAnswersPageProps> = ({ studentAnswers }) => {
+const LAnswersPage: React.FC<LAnswersPageProps> = ({
+  studentAnswers,
+  onBack,
+}) => {
   const [partIndex, setPartIndex] = useState(0);
 
   // TODO: this should be a parameter
@@ -32,7 +36,7 @@ const LAnswersPage: React.FC<LAnswersPageProps> = ({ studentAnswers }) => {
         <span>Help</span>
         <BsQuestionLg className="inline ml-2" size={16} />
       </span>
-      <span className={linkStyling + ' mr-auto'}>00:10</span>
+      <span className={linkStyling + ' mr-auto'}></span>
       {parts.map((_, i) => (
         <button
           className={
@@ -51,7 +55,7 @@ const LAnswersPage: React.FC<LAnswersPageProps> = ({ studentAnswers }) => {
   const TitleRow = (
     <div className="w-full h-full flex items-center border-b-2">
       <div className="sm:w-1/3 w-1/2 h-full nav-item">
-        <button className="hover:text-gray-700">
+        <button className="hover:text-gray-700" onClick={onBack}>
           <BsArrowLeft className="inline mr-2" />
           <span>Back</span>
         </button>

--- a/packages/frontend/src/pages/RAnswersPage.tsx
+++ b/packages/frontend/src/pages/RAnswersPage.tsx
@@ -1,54 +1,30 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import '../stylesheets/readingStyling.css';
 import '../stylesheets/exam.css';
-import { readingParts } from '../utilities/LRSampleQuestions';
 import { PassageComponent } from '../components/Reading/PassageComponent';
-import { get } from 'aws-amplify/api';
-import { toJSON } from '../utilities';
 import { BsChevronUp, BsQuestionLg } from 'react-icons/bs';
 import { QuestionsComponent } from '../components/Reading/QuestionsComponent';
-import { useParams } from 'react-router-dom';
 import { BsArrowLeft } from 'react-icons/bs';
+import { ReadingPart } from '../../../functions/src/utilities/fullTestUtilities';
 
-const RAnswersPage = () => {
-  const { sk } = useParams<{
-    sk: string | undefined;
-  }>();
-  const [data, setData] = useState<any>(null);
+type RAnswersPageProps = {
+  readingParts: ReadingPart[];
+  studentAnswers: any;
+  onBack: () => void;
+};
+
+const RAnswersPage: React.FC<RAnswersPageProps> = ({
+  readingParts,
+  studentAnswers,
+  onBack,
+}) => {
   const [partIndex, setPartIndex] = useState(0);
   const [isMaximized, setIsMaximized] = useState(false);
-
-  useEffect(() => {
-    if (!sk) return;
-    console.log(' sk: ', sk);
-    toJSON(
-      get({
-        apiName: 'myAPI',
-        path: `/scores/reading/${sk}`,
-      }),
-    )
-      .then(data => {
-        setData(data);
-        console.log('data: ', data);
-      })
-      .catch(error => {
-        console.error(error);
-      });
-  }, [sk]);
-
-  if (!data) {
-    return (
-      <div className="text-lg px-10 text-center mb-8 mt-6">Loading...</div>
-    );
-  }
-
-  // TODO: this should be a parameter
-  const parts = readingParts;
 
   const TitleRow = (
     <div className="w-full h-full flex items-center border-b-2">
       <div className="sm:w-1/3 w-1/2 h-full nav-item">
-        <button className="hover:text-gray-700">
+        <button className="hover:text-gray-700" onClick={onBack}>
           <BsArrowLeft className="inline mr-2" />
           <span>Back</span>
         </button>
@@ -69,7 +45,7 @@ const RAnswersPage = () => {
         <BsQuestionLg className="inline ml-2" size={16} />
       </span>
       <span className={linkStyling + ' mr-auto'}>00:10</span>
-      {parts.map((_, i) => (
+      {readingParts.map((_, i) => (
         <button
           className={
             linkStyling +
@@ -102,7 +78,7 @@ const RAnswersPage = () => {
     <div className="h-full">
       <div className="h-[90%] lg:h-full overflow-y-scroll p-8 max-lg:pb-0">
         <PassageComponent
-          readingPart={parts[partIndex]}
+          readingPart={readingParts[partIndex]}
           PartIndex={partIndex}
         />
       </div>
@@ -116,9 +92,9 @@ const RAnswersPage = () => {
       <div className="h-[10%] lg:hidden"></div>
       <div className="h-[90%] lg:h-full overflow-y-scroll p-8 max-lg:pt-0">
         <QuestionsComponent
-          questions={parts[partIndex].Questions}
-          answers={data.studentAnswers[partIndex]}
-          setAnswers={data.studentAnswers[partIndex]}
+          questions={readingParts[partIndex].Questions}
+          answers={studentAnswers[partIndex]}
+          setAnswers={studentAnswers[partIndex]}
           showCorrectAnswer={true}
         />
       </div>

--- a/packages/frontend/src/pages/sections.tsx
+++ b/packages/frontend/src/pages/sections.tsx
@@ -38,6 +38,9 @@ const sections = () => (
     <Link to="/full-test">
       <Button label="full test" />
     </Link>
+    <Link to="/feedback/somethin">
+      <Button label="Feedback" />
+    </Link>
   </>
 );
 

--- a/packages/frontend/src/routes.tsx
+++ b/packages/frontend/src/routes.tsx
@@ -21,7 +21,7 @@ import { SignOutPage } from './pages/signOut.tsx';
 import ErrorPage from './pages/ErrorPage.tsx';
 // import { WritingPage } from './pages/WritingPage.tsx';
 //import { writingSection } from './utilities.ts';
-import RAnswersPage from './pages/RAnswersPage.tsx';
+// import RAnswersPage from './pages/RAnswersPage.tsx';
 import { SpeakingAudioPage } from './pages/SpeakingAudioPage.tsx';
 import { SpeakingCardPage } from './pages/SpeakingCardPage.tsx';
 // import { ListeningQuestionsPage } from './pages/ListeningQuestionsPage.tsx';
@@ -133,10 +133,10 @@ const noLayoutRoutes: RouteObject[] = [
     path: '/scores/:section/:sk',
     Component: LRFeedbackPage,
   },
-  {
-    path: '/answers/reading/:sk',
-    Component: RAnswersPage,
-  },
+  // {
+  //   path: '/answers/reading/:sk',
+  //   Component: RAnswersPage,
+  // },
   // {
   //   path: '/answers/listening/:sk',
   //   Component: LAnswersPage,

--- a/packages/frontend/src/routes.tsx
+++ b/packages/frontend/src/routes.tsx
@@ -101,10 +101,6 @@ const notLandingRoutes: RouteObject[] = [
     path: '/PlacementTest',
     Component: PlacementTest,
   },
-  {
-    path: '/feedback/:sk',
-    Component: AllFeedbacks,
-  },
 ];
 
 const noLayoutRoutes: RouteObject[] = [
@@ -119,6 +115,10 @@ const noLayoutRoutes: RouteObject[] = [
   {
     path: '/full-test',
     Component: FullTestPage,
+  },
+  {
+    path: '/feedback/:testId',
+    Component: AllFeedbacks,
   },
   // These pages don't use `Layout` yet
   // {

--- a/packages/frontend/src/routes.tsx
+++ b/packages/frontend/src/routes.tsx
@@ -28,6 +28,7 @@ import { SpeakingCardPage } from './pages/SpeakingCardPage.tsx';
 // import { ListeningQuestionsPage } from './pages/ListeningQuestionsPage.tsx';
 import { FullTestPage } from './pages/FullTestPage.tsx';
 import { ProfilePage } from './pages/ProfilePage.tsx';
+import { AllFeedbacks } from './components/AllFeedbacks.tsx';
 
 // These routes will have the landing nav bar
 const landingRoutes: RouteObject[] = [
@@ -100,6 +101,10 @@ const notLandingRoutes: RouteObject[] = [
   {
     path: '/PlacementTest',
     Component: PlacementTest,
+  },
+  {
+    path: '/feedback/:sk',
+    Component: AllFeedbacks,
   },
 ];
 

--- a/packages/frontend/src/routes.tsx
+++ b/packages/frontend/src/routes.tsx
@@ -22,7 +22,6 @@ import ErrorPage from './pages/ErrorPage.tsx';
 // import { WritingPage } from './pages/WritingPage.tsx';
 //import { writingSection } from './utilities.ts';
 import RAnswersPage from './pages/RAnswersPage.tsx';
-import LAnswersPage from './pages/LAnswersPage.tsx';
 import { SpeakingAudioPage } from './pages/SpeakingAudioPage.tsx';
 import { SpeakingCardPage } from './pages/SpeakingCardPage.tsx';
 // import { ListeningQuestionsPage } from './pages/ListeningQuestionsPage.tsx';
@@ -138,10 +137,10 @@ const noLayoutRoutes: RouteObject[] = [
     path: '/answers/reading/:sk',
     Component: RAnswersPage,
   },
-  {
-    path: '/answers/listening/:sk',
-    Component: LAnswersPage,
-  },
+  // {
+  //   path: '/answers/listening/:sk',
+  //   Component: LAnswersPage,
+  // },
   {
     path: '/test-speaking-card-ui',
     Component: SpeakingCardPage,


### PR DESCRIPTION
Started working on making a front-end page that will only contain the functionality and logic that we need for integrating the back-end endpoint we already have for retrieving feedback, with the feedback components we already have.

This is still a work in progress.  For now what I have is the listening answers page and reading scores outside.

Couple of things to note (for me):
- I haven't implemented a way of redirecting from fulltest to this page (with the full test item cached).
- The current page should control the presence of the navbar.
- I need interface to switch between the different feedbacks for writing and speaking.
- I need to add working back buttons, at least for reading and listening answer pages.