### PR TITLE
Wrap up fulltest feedback functionality

### DIFF
--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { FullTestItem } from '../../../functions/src/utilities/fullTestUtilities';
 import { Button } from './Button';
 import { get } from 'aws-amplify/api';
-import { toJSON } from '../utilities';
+import { getCachedFeedback, setCachedFeedback, toJSON } from '../utilities';
 import { Spinner } from './Spinner';
 import { useNavigate, useParams } from 'react-router-dom';
 import LAnswersPage from '../pages/LAnswersPage';
@@ -163,16 +163,4 @@ export const AllFeedbacks: React.FC = () => {
   }
 
   return out;
-};
-
-const getFeedbackKey = (testId: string) => `FeedbackItem-${testId}`;
-
-const getCachedFeedback = (testId: string) => {
-  const localData = sessionStorage.getItem(getFeedbackKey(testId));
-  if (localData) console.log('Using cached', { localData });
-  return localData ? JSON.parse(localData) : localData;
-};
-
-export const setCachedFeedback = (feedback: any, testId: string) => {
-  sessionStorage.setItem(getFeedbackKey(testId), JSON.stringify(feedback));
 };

--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -162,16 +162,7 @@ export const AllFeedbacks: React.FC = () => {
       break;
   }
 
-  return (
-    <>
-      {out}
-      {screen !== 'general' && (
-        <div className="mt-20">
-          <Button onClick={() => setScreen('general')}>Back</Button>
-        </div>
-      )}
-    </>
-  );
+  return out;
 };
 
 const getFeedbackKey = (testId: string) => `FeedbackItem-${testId}`;

--- a/packages/frontend/src/components/AllFeedbacks.tsx
+++ b/packages/frontend/src/components/AllFeedbacks.tsx
@@ -5,10 +5,10 @@ import { get } from 'aws-amplify/api';
 import { toJSON } from '../utilities';
 import { Spinner } from './Spinner';
 import { useNavigate, useParams } from 'react-router-dom';
-import { WSFeedbackComponent } from './WSFeedback';
 import LAnswersPage from '../pages/LAnswersPage';
 import { Layout } from '../Layout';
 import RAnswersPage from '../pages/RAnswersPage';
+import { WSFeedbackPage } from './WSFeedbackPage';
 
 type Screens = 'general' | 'listening' | 'reading' | 'writing' | 'speaking';
 type DataType = { fullItem: FullTestItem } | undefined | { message: string };
@@ -143,17 +143,22 @@ export const AllFeedbacks: React.FC = () => {
       break;
 
     case 'writing':
-      const feedback = data.fullItem?.writingAnswer?.feedback;
+    case 'speaking':
+      const feedback =
+        screen === 'writing'
+          ? data.fullItem?.writingAnswer?.feedback
+          : data.fullItem?.speakingAnswer?.feedback;
       if (!feedback) break;
 
-      out = feedback.map((taskFeedback, key) => (
-        <WSFeedbackComponent feedback={taskFeedback} key={key} />
-      ));
-      out = <Layout>{out}</Layout>;
+      out = (
+        <Layout>
+          <WSFeedbackPage
+            feedback={feedback}
+            onBack={() => setScreen('general')}
+          />
+        </Layout>
+      );
 
-      break;
-
-    case 'speaking':
       break;
   }
 

--- a/packages/frontend/src/components/TestComponents.tsx
+++ b/packages/frontend/src/components/TestComponents.tsx
@@ -21,12 +21,16 @@ export const TitleRow: React.FC<TitleRowProps> = ({
       </div>
       <div className="w-1/3 text-center font-light text-xl">{title}</div>
       <div className="w-1/3 nav-item flex-row justify-end">
-        <button onClick={onSave} className="mr-2">
-          Save <BsFloppy2 className="inline max-sm:hidden mr-4" />
-        </button>
-        <button onClick={onSubmit}>
-          Submit <BsCheckLg className="inline max-sm:hidden" />
-        </button>
+        {onSave && (
+          <button onClick={onSave} className="mr-2">
+            Save <BsFloppy2 className="inline max-sm:hidden mr-4" />
+          </button>
+        )}
+        {onSubmit && (
+          <button onClick={onSubmit}>
+            Submit <BsCheckLg className="inline max-sm:hidden" />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/packages/frontend/src/components/TestComponents.tsx
+++ b/packages/frontend/src/components/TestComponents.tsx
@@ -5,20 +5,19 @@ type TitleRowProps = {
   title: string;
   onSubmit?: MouseEventHandler;
   onSave?: MouseEventHandler;
+  onBack?: MouseEventHandler;
 };
 
 export const TitleRow: React.FC<TitleRowProps> = ({
   title,
   onSubmit,
   onSave,
+  onBack,
 }) => {
   return (
     <div className="w-full h-full flex items-center border-b-2">
       <div className="w-1/3 h-full nav-item">
-        <button className="hover:text-gray-700">
-          <BsArrowLeft className="inline mr-2" />
-          <span>Back</span>
-        </button>
+        {onBack && <BackButton onBack={onBack} />}
       </div>
       <div className="w-1/3 text-center font-light text-xl">{title}</div>
       <div className="w-1/3 nav-item flex-row justify-end">
@@ -30,5 +29,18 @@ export const TitleRow: React.FC<TitleRowProps> = ({
         </button>
       </div>
     </div>
+  );
+};
+
+type BackButtonProps = {
+  onBack?: MouseEventHandler;
+};
+
+export const BackButton: React.FC<BackButtonProps> = ({ onBack }) => {
+  return (
+    <button onClick={onBack} className="hover:text-gray-700">
+      <BsArrowLeft className="inline mr-2" />
+      <span>Back</span>
+    </button>
   );
 };

--- a/packages/frontend/src/components/WSFeedback.tsx
+++ b/packages/frontend/src/components/WSFeedback.tsx
@@ -147,7 +147,7 @@ const displayGrammarMistakes = (
   });
 };
 
-function isWritingFeedback(
+export function isWritingFeedback(
   feedback: SpeakingFeedback | WritingFeedback,
 ): feedback is WritingFeedback {
   return !('Pronunciation' in feedback);

--- a/packages/frontend/src/components/WSFeedbackPage.tsx
+++ b/packages/frontend/src/components/WSFeedbackPage.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import {
+  SpeakingFeedbackAll,
+  WritingFeedbackAll,
+} from '../../../functions/src/utilities/fullTestUtilities';
+import { Button } from './Button';
+import { BackButton } from './TestComponents';
+import { WSFeedbackComponent, isWritingFeedback } from './WSFeedback';
+
+type WSFeedbackPageProps = {
+  feedback: SpeakingFeedbackAll | WritingFeedbackAll;
+  onBack: () => void;
+};
+
+export const WSFeedbackPage: React.FC<WSFeedbackPageProps> = ({
+  feedback,
+  onBack,
+}) => {
+  const [feedbackIndex, setFeedbackIndex] = useState(0);
+
+  const buttonLabel = isWritingFeedback(feedback[0]) ? 'Task' : 'Part';
+  const pageHeader = (
+    <div className="flex">
+      <BackButton onBack={onBack} />
+
+      <div className="ml-auto"></div>
+
+      {feedback.map((_, index) => (
+        <Button
+          onClick={() => setFeedbackIndex(index)}
+          key={index}
+          isTransparent={index !== feedbackIndex}
+        >
+          {buttonLabel} {index + 1}
+        </Button>
+      ))}
+    </div>
+  );
+
+  return (
+    <>
+      <div className="mb-12">{pageHeader}</div>
+      <WSFeedbackComponent feedback={feedback[feedbackIndex]} />
+    </>
+  );
+};

--- a/packages/frontend/src/pages/FullTestPage.tsx
+++ b/packages/frontend/src/pages/FullTestPage.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Layout } from '../Layout';
 import { ConfirmFullTestStart } from '../components/ConfirmFullTestStart';
 import useWebSocket, { ReadyState } from 'react-use-websocket';
-import { useSocketUrl } from '../utilities';
+import { setCachedFeedback, useSocketUrl } from '../utilities';
 import { useState } from 'react';
 import { ListeningQuestionsPage } from './ListeningQuestionsPage';
 import ReadingQuestions from './ReadingQuestionsPage';
@@ -10,7 +10,6 @@ import { Spinner } from '../components/Spinner';
 import { WritingPage } from './WritingPage';
 import { IntermediatePage } from '../components/IntermediatePage';
 import { ToastContainer, toast } from 'react-toastify';
-import { setCachedFeedback } from '../components/AllFeedbacks';
 
 export const FullTestPage = () => {
   let out;

--- a/packages/frontend/src/pages/sections.tsx
+++ b/packages/frontend/src/pages/sections.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import Button from '../components/TButton';
-import { setCachedFeedback } from '../components/AllFeedbacks';
+import { setCachedFeedback } from '../utilities';
 import { sampleFullTest } from '../utilities/sampleFullTest';
 
 const sections = () => (

--- a/packages/frontend/src/pages/sections.tsx
+++ b/packages/frontend/src/pages/sections.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom';
 import Button from '../components/TButton';
+import { setCachedFeedback } from '../components/AllFeedbacks';
+import { sampleFullTest } from '../utilities/sampleFullTest';
 
 const sections = () => (
   <>
@@ -38,8 +40,13 @@ const sections = () => (
     <Link to="/full-test">
       <Button label="full test" />
     </Link>
-    <Link to="/feedback/somethin">
-      <Button label="Feedback" />
+    <Link
+      to="/feedback/1717941628284-sample"
+      onClick={() =>
+        setCachedFeedback({ fullItem: sampleFullTest }, '1717941628284-sample')
+      }
+    >
+      <Button label="Sample Feedback" />
     </Link>
   </>
 );

--- a/packages/frontend/src/utilities.ts
+++ b/packages/frontend/src/utilities.ts
@@ -24,3 +24,28 @@ export const useSocketUrl = (): string | undefined => {
   // console.log(`URL is ${import.meta.env.VITE_WEBSOCKET_URL}?idToken=${token}`);
   return `${import.meta.env.VITE_WEBSOCKET_URL}?idToken=${token}`;
 };
+
+////// Full Test Feedback Cache //////
+const getFeedbackKey = (testId: string) => `FeedbackItem-${testId}`;
+
+/**
+ * Pull cached feedback from browser storage
+ *
+ * @param testId  The `id` of the test.
+ * @returns the full test item if it exists, null otherwise
+ */
+export const getCachedFeedback = (testId: string) => {
+  const localData = sessionStorage.getItem(getFeedbackKey(testId));
+  if (localData) console.log('Using cached', { localData });
+  return localData ? JSON.parse(localData) : localData;
+};
+
+/**
+ * Cach feedback in browser storage.
+ *
+ * @param feedback  The feedback to store in cache
+ * @param testId  The `id` of the test.
+ */
+export const setCachedFeedback = (feedback: any, testId: string) => {
+  sessionStorage.setItem(getFeedbackKey(testId), JSON.stringify(feedback));
+};


### PR DESCRIPTION
For now I have the route `/feedback/...` which handles the functionality of integrating with back-end as well as components we already had.

Changes:
- The page retrieves feedback from database and caches it in `sessionStorage`.  
- All exam sections are now integrated properly.

Some components where introduced.
- `WSFeedbackPage`
- `BackButton`

All that is left is for the general feedback page to be designed by @ErasedKyte.

