### PR TITLE
Add types for training plan

### DIFF
--- a/packages/frontend/src/utilities/planTypes.ts
+++ b/packages/frontend/src/utilities/planTypes.ts
@@ -33,7 +33,8 @@ export type Plan = {
  * alongside his training plans if any.
  */
 export type Profile = {
-  uid: string;
+  PK: string; // this is the uid
+  SK: 'plan';
   listening?: Plan;
   reading?: Plan;
   vocab?: Plan;

--- a/packages/frontend/src/utilities/planTypes.ts
+++ b/packages/frontend/src/utilities/planTypes.ts
@@ -1,0 +1,44 @@
+import { LRQuestion } from './LRUtilities';
+
+export type Challenge = {
+  context: string;
+  contextAudio?: string;
+  tasks: LRQuestion[];
+};
+
+/** This is the structure of the hard-coded plans that will be stored in the
+ * database.  These will be used to create a plan for each user when he takes
+ * the sections test.
+ */
+export type PlanTemplate = {
+  challenges: Array<{
+    challengeId: string;
+    isCompleted: false;
+  }>;
+};
+
+/**
+ * This repsenets a training plan.  This type is used in `Profile`.
+ */
+export type Plan = {
+  challenges: Array<{
+    challengeId: string;
+    isCompleted: boolean;
+  }>;
+  level: CefrLevel;
+};
+
+/**
+ * Each user has a profile of his own, which will contain user information
+ * alongside his training plans if any.
+ */
+export type Profile = {
+  uid: string;
+  listening?: Plan;
+  reading?: Plan;
+  vocab?: Plan;
+  writing?: Plan;
+  speaking?: Plan;
+};
+
+export type CefrLevel = 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2';

--- a/packages/frontend/src/utilities/sampleChallenge.ts
+++ b/packages/frontend/src/utilities/sampleChallenge.ts
@@ -1,10 +1,4 @@
-import { LRQuestion } from './LRUtilities';
-
-export type Challenge = {
-  context: string;
-  contextAudio?: string;
-  tasks: LRQuestion[];
-};
+import { Challenge } from './planTypes';
 
 export const sampleChallenge: Challenge = {
   context: 'Here should be a context paragraph', // I added this and moved the audio file to contextAudio

--- a/packages/frontend/src/utilities/sampleProfile.ts
+++ b/packages/frontend/src/utilities/sampleProfile.ts
@@ -1,0 +1,43 @@
+import { Profile } from './planTypes';
+
+//  this will include dummy data for the profile
+export const sampleProfile: Profile = {
+  PK: '123456',
+  SK: 'plan',
+  listening: {
+    challenges: [
+      { challengeId: '1', isCompleted: true },
+      { challengeId: '2', isCompleted: true },
+      { challengeId: '3', isCompleted: false },
+      { challengeId: '4', isCompleted: false },
+      { challengeId: '5', isCompleted: false },
+    ],
+    level: 'A2',
+  },
+  speaking: {
+    challenges: [
+      { challengeId: '1', isCompleted: true },
+      { challengeId: '2', isCompleted: false },
+      { challengeId: '3', isCompleted: false },
+    ],
+    level: 'B2',
+  },
+  reading: {
+    challenges: [
+      { challengeId: '1', isCompleted: false },
+      { challengeId: '2', isCompleted: false },
+      { challengeId: '3', isCompleted: false },
+    ],
+    level: 'A1',
+  },
+  vocab: {
+    challenges: [
+      { challengeId: '1', isCompleted: true },
+      { challengeId: '2', isCompleted: true },
+      { challengeId: '3', isCompleted: false },
+      { challengeId: '4', isCompleted: false },
+    ],
+    level: 'B1',
+  },
+  // writing plan is missing to support the case of no plan available
+};


### PR DESCRIPTION
Added initial types for the plan. 

We already have a sample challenge at hand.  All that is left is to create a sample profile, so that @ThatIsHero can start working on the plan page, with the correct structure. (I'd appreciate it if you can pick this up @Ma-hawaj).